### PR TITLE
Deploy Mealie in Kubernetes Cluster

### DIFF
--- a/kubernetes/apps/mealie/mealie-ingressroute.yaml
+++ b/kubernetes/apps/mealie/mealie-ingressroute.yaml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: mealie
+  namespace: mealie
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`mealie.atlasmalt.com`)
+      kind: Rule
+      services:
+        - name: mealie
+          port: 9000
+  tls:
+    secretName: mealie-tls  # ✅ Must match the Certificate resource secretName

--- a/kubernetes/certificates/mealie-certificate.yaml
+++ b/kubernetes/certificates/mealie-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mealie-tls
+  namespace: monitoring
+spec:
+  secretName: mealie-tls  # ✅ Cert-Manager will create this Secret automatically
+  issuerRef:
+    name: ${CERT_ISSUER}  # This will be replaced by the script
+    kind: ClusterIssuer
+  dnsNames:
+    - mealie.atlasmalt.com  # ✅ This must match the domain in your IngressRoute

--- a/kubernetes/helm/values/mealie-values.yaml
+++ b/kubernetes/helm/values/mealie-values.yaml
@@ -1,0 +1,38 @@
+strategy:
+  type: Recreate
+
+controllers:
+  main:
+    enabled: true
+    containers:
+      main:
+        image:
+          repository: ghcr.io/mealie-recipes/mealie
+          tag: latest  # Ensure you're using the latest stable release
+          pullPolicy: IfNotPresent
+        env:
+          TZ: America/New_York  # Set to Eastern Time
+          BASE_URL: "https://mealie.atlasmalt.com"
+          DB_ENGINE: sqlite
+          SQLITE_DB_FILE: "/app/data/mealie.db"
+          ALLOW_SIGNUP: "false"  # Disable user signups
+          TOKEN_TIME: "96"  # Token expiration time in hours
+
+service:
+  main:
+    controller: main
+    ports:
+      http: 
+        port: 9000
+
+persistence:
+  data:
+    enabled: true
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    storageClass: longhorn
+    advancedMounts:
+      main:
+        main:
+          - path: /app/data/
+            readOnly: false

--- a/kubernetes/scripts/helpers/deploy-mealie.sh
+++ b/kubernetes/scripts/helpers/deploy-mealie.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e  # Exit on error
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+
+# Define paths to manifests
+MEALIE_APP_PATH="$APPS_PATH/mealie"
+
+echo "📡 Deploying Mealie..."
+
+# Create Namespace
+kubectl create namespace mealie || true
+
+# Deploy Mealie
+helm repo add mealie https://jvalskis.github.io/mealie-helm/
+helm repo update
+helm upgrade --install mealie mealie/mealie \
+  --namespace mealie \
+  --values "$HELM_PATH/values/mealie-values.yaml"
+
+# Apply TLS Certificates for Mealie
+echo "🔐 Deploying Mealie TLS Certificates..."
+cat "$CERTS_PATH/mealie-certificate.yaml" | envsubst | kubectl apply -f -
+echo "✅ Certificates Deployed!"
+
+# Apply Ingress Routes for Mealie
+echo "🔐 Deploying IngressRoutes..."
+kubectl apply -f "$MEALIE_APP_PATH/mealie-ingressroute.yaml"
+echo "✅ IngressRoutes Deployed!"
+
+echo "✅ Mealie Deployed Successfully!"


### PR DESCRIPTION
This PR introduces the deployment of Mealie in the Kubernetes cluster using Helm, along with TLS certificate management and Ingress routing through Traefik. The deployment follows the structured migration process, ensuring persistence, security, and automation.
Changes Included:

✅ IngressRoute for Mealie (mealie-ingressroute.yaml)

    Defines external access via Traefik v3.
    Implements TLS termination using a pre-configured certificate.

✅ TLS Certificate Configuration (mealie-certificate.yaml)

    Uses Cert-Manager to request and manage TLS certificates for mealie.atlasmalt.com.
    Uses a ClusterIssuer reference for automated certificate issuance.

✅ Helm Values Configuration (mealie-values.yaml)

    Specifies SQLite as the database backend.
    Defines persistent storage using Longhorn (10Gi volume).
    Restricts signups (ALLOW_SIGNUP: false) and sets token expiration to 96 hours.
    Configures container environment variables to align with production needs.

✅ Deployment Automation (deploy-mealie.sh)

    Automates Mealie deployment using Helm.
    Ensures TLS certificates are applied correctly.
    Deploys the IngressRoute for external access.