### PR TITLE
Longhorn Configuration Enhancements & Automation Refinements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.env
+
 # Local .terraform directories
 **/.terraform/*
 

--- a/kubernetes/apps/longhorn/disable-longhorn-scheduling.yaml
+++ b/kubernetes/apps/longhorn/disable-longhorn-scheduling.yaml
@@ -1,0 +1,7 @@
+apiVersion: longhorn.io/v1beta1
+kind: Node
+metadata:
+  name: atlasmalt-kube-vm-control
+  namespace: longhorn-system
+spec:
+  allowScheduling: false

--- a/kubernetes/scripts/helpers/deploy-longhorn.sh
+++ b/kubernetes/scripts/helpers/deploy-longhorn.sh
@@ -36,6 +36,12 @@ kubectl apply -f "$LONGHORN_APP_PATH/longhorn-ingressroute.yaml"
 # Update local-path to not be default storage class
 kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 
+echo "Waiting for Longhorn to be fully available..."
+kubectl wait --for=condition=available --timeout=300s deployment --all -n longhorn-system
+
+echo "Applying patch to disable scheduling on the control-plane node..."
+kubectl apply -f "$LONGHORN_APP_PATH/disable-longhorn-scheduling.yaml"
+
 echo "✅ Longhorn deployment completed successfully!"
 
 echo "🎉 Longhorn deployed!"

--- a/kubernetes/scripts/nuke-deploy-cluster.sh
+++ b/kubernetes/scripts/nuke-deploy-cluster.sh
@@ -42,7 +42,11 @@ done
 echo "Done!"
 
 echo "🛑 Import K3s KUBECONFIG..."
-rm ~/.kube/atlasmalt_config
+
+if [ -f ~/.kube/atlasmalt_config ]; then
+  rm ~/.kube/atlasmalt_config
+fi
+
 ssh -o StrictHostKeyChecking=no ubuntu@192.168.14.80 "sudo cat /etc/rancher/k3s/k3s.yaml" > ~/.kube/atlasmalt_config
 sed -i '' 's/127.0.0.1/192.168.14.80/g' ~/.kube/atlasmalt_config
 echo "✅ Done!"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,11 +17,6 @@ variable "k3s_cluster_main_pool_name" {
   description = "Main storage pool name for all nodes"
 }
 
-# Create a storage pools for distributed drives
-variable "longhorn_storage_pools" {
-  type = map(string)
-}
-
 variable "control_plane_ip" {
   type        = string
   description = "IP address of the K3s control plane"
@@ -54,7 +49,9 @@ variable "k3s_nodes" {
     ram               = number
     disk              = number
     cloud_init        = string  # e.g. "control-plane" or "worker-node"
-    longhorn_disk_path = string # If non-empty, create & attach a 1TB disk
+    longhorn_pool_name = string
+    longhorn_pool_path = string
+    longhorn_disk = string # If non-empty, create & attach a 1TB disk
     ip_address        = string
     hostname          = string
   }))


### PR DESCRIPTION
This PR introduces multiple improvements to Longhorn deployment and Terraform storage configurations in the `docker2kubernetes` project. These changes enhance automation, improve reliability, and refine the infrastructure-as-code setup to support more dynamic and scalable Longhorn storage.

---

### **Key Changes**
#### **🔧 Longhorn Deployment & Scheduling**
- Added `disable-longhorn-scheduling.yaml` to prevent scheduling on the control plane node (`atlasmalt-kube-vm-control`).
- Modified `deploy-longhorn.sh` to:
  - Apply the new scheduling restriction automatically.

#### **🛠️ Cluster Reset & Re-deployment**
- Updated `nuke-deploy-cluster.sh` to ensure `.kube/atlasmalt_config` is properly removed and recreated before re-importing the kubeconfig.
- Improved idempotency by checking if the kubeconfig exists before attempting to delete it.

#### **🗄️ Terraform Storage Configuration for Longhorn**
- Refactored `main.tf` to:
  - Use dynamic storage pool creation based on node attributes.
  - Simplify disk attachment logic to ensure proper association with worker nodes.
- Removed unused `longhorn_storage_pools` variable from `variables.tf` and updated `k3s_nodes` structure to accommodate better disk mapping.

#### **📄 Miscellaneous**
- Updated `.gitignore` to include `.env` files to avoid committing environment-specific settings.

---

### **Why These Changes?**
- **Improved Longhorn reliability**: Preventing scheduling on the control plane enhances cluster stability.
- **Better automation**: Eliminates manual steps when deploying Longhorn.
- **Dynamic Terraform storage allocation**: Ensures each worker node gets the correct storage pool configuration automatically.
- **Idempotency & Cleanup**: Ensures cluster reset (`nuke-deploy-cluster.sh`) does not leave stale kubeconfig files.

---