### PR TITLE
Clean Up Tech Debt - Longhorn / Node Labels / Taints / Locked Down control-plane

### DIFF
--- a/kubernetes/helm/charts/gitea/templates/volumes.yaml
+++ b/kubernetes/helm/charts/gitea/templates/volumes.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.persistenceLonghorn.enabled }}
+{{- /*
+Convert a size in Gi (e.g. "5Gi") to bytes.
+*/ -}}
+{{- $sizeStr := .Values.persistenceLonghorn.size | trimSuffix "Gi" -}}
+{{- $sizeGi := $sizeStr | int -}}
+{{- $sizeBytes := mul $sizeGi (mul 1024 (mul 1024 1024)) -}}
+
+apiVersion: longhorn.io/v1beta2
+kind: Volume
+metadata:
+  name: {{ .Values.persistenceLonghorn.pvName | quote }}
+  namespace: longhorn-system
+spec:
+  numberOfReplicas: {{ .Values.persistenceLonghorn.numberOfReplicas }}
+  frontend: {{ .Values.persistenceLonghorn.frontend | quote }}
+  backupTargetName: {{ .Values.persistenceLonghorn.backupTargetName | quote }}
+  size: "{{ $sizeBytes }}"
+  {{- if .Values.persistenceLonghorn.restore }}
+  fromBackup: {{ .Values.persistenceLonghorn.fromBackup | quote }}
+  {{- end }}
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.persistenceLonghorn.pvcName | quote }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - {{ .Values.persistenceLonghorn.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistenceLonghorn.size | quote }}
+  storageClassName: {{ .Values.persistenceLonghorn.storageClassName | quote }}
+  volumeName: {{ .Values.persistenceLonghorn.pvName | quote }}
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.persistenceLonghorn.pvName | quote }}
+spec:
+  capacity:
+    storage: {{ .Values.persistenceLonghorn.size | quote }}
+  volumeMode: Filesystem
+  accessModes:
+    - {{ .Values.persistenceLonghorn.accessMode | quote }}
+  persistentVolumeReclaimPolicy: {{ .Values.persistenceLonghorn.reclaimPolicy | quote }}
+  storageClassName: {{ .Values.persistenceLonghorn.storageClassName | quote }}
+  csi:
+    driver: {{ .Values.persistenceLonghorn.csiDriver | quote }}
+    volumeHandle: {{ .Values.persistenceLonghorn.pvName | quote }}
+
+{{- end }}

--- a/kubernetes/helm/values/gitea-values.yaml
+++ b/kubernetes/helm/values/gitea-values.yaml
@@ -1,0 +1,62 @@
+gitea:
+  persistence:
+    enabled: true      # Make sure persistence is enabled
+    create: false
+    claimName: "gitea-pvc"  # Replace with the name of your existing PVC
+    # size: 8Gi
+  service:
+    http:
+      clusterIP: ""
+  postgresql:
+    enabled: false
+  postgresql-ha:
+    enabled: false
+  redis:
+    enabled: false
+  redis-cluster:
+    enabled: false
+  gitea:
+    additionalConfigFromEnvs:
+      - name: GITEA__SERVER__ROOT_URL
+        value: https://git.atlasmalt.com/
+      - name: GITEA__SERVER__DOMAIN
+        value: git.atlasmalt.com
+      - name: GITEA__SERVER__SSH_DOMAIN
+        value: git.atlasmalt.com
+    config:
+      database:
+        DB_TYPE: sqlite3
+
+ingressroute:
+  enabled: true
+  host: "git.atlasmalt.com"
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
+    traefik.ingress.kubernetes.io/router.tls: "true"
+  tls:
+    secretName: "gitea-tls"
+
+certificate:
+  enabled: true
+  name: gitea-tls
+  secretName: gitea-tls
+  issuer:
+    name: "letsencrypt-staging"  # This value can be set via your CI/CD pipeline or .env file
+    kind: ClusterIssuer
+  dnsNames:
+    - git.atlasmalt.com
+
+persistenceLonghorn:
+  enabled: true
+  restore: true
+  pvcName: "gitea-pvc"
+  pvName: "gitea-pv"       # Used for the static PV (restored volume)
+  size: "8Gi"
+  accessMode: "ReadWriteOnce"
+  reclaimPolicy: "Retain"
+  storageClassName: "longhorn"
+  csiDriver: "driver.longhorn.io"
+  numberOfReplicas: 3
+  frontend: blockdev
+  backupTargetName: default
+  fromBackup: "s3://longhorn-backups@192.168.14.222:9900/longhorn?backup=dummy_backup_id&volume=gitea-pv"

--- a/kubernetes/helm/values/longhorn-values.yaml
+++ b/kubernetes/helm/values/longhorn-values.yaml
@@ -3,6 +3,12 @@ longhorn:
     defaultClass: true
     defaultFsType: ext4
     reclaimPolicy: Retain
+    defaultNodeSelector:
+      enable: true
+      selector: "longhorn-true"
+
+  defaultSettings:
+    createDefaultDiskLabeledNodes: true
 
   ingress:
     enabled: false

--- a/kubernetes/scripts/helpers/deploy-gitea.sh
+++ b/kubernetes/scripts/helpers/deploy-gitea.sh
@@ -11,7 +11,7 @@ kubectl create namespace gitea || true
 
 # Restore Persistent Volume from backup for Gitea
 echo "🔐 Restoring Data Volume..."
-./longhorn-automation.sh restore gitea pvc-90375b86-e77a-4bfb-9e91-28cbd4983e18
+./longhorn-automation.sh restore gitea
 echo "✅ Persistent Data Volume Restored!"
 
 # Deploy Gitea

--- a/kubernetes/scripts/helpers/deploy-gitea.sh
+++ b/kubernetes/scripts/helpers/deploy-gitea.sh
@@ -11,7 +11,7 @@ kubectl create namespace gitea || true
 
 # Restore Persistent Volume from backup for Gitea
 echo "🔐 Restoring Data Volume..."
-./longhorn-automation.sh restore gitea
+./longhorn-automation.sh restore gitea pvc-90375b86-e77a-4bfb-9e91-28cbd4983e18 --wrapper
 echo "✅ Persistent Data Volume Restored!"
 
 # Deploy Gitea

--- a/kubernetes/scripts/helpers/deploy-gitea.sh
+++ b/kubernetes/scripts/helpers/deploy-gitea.sh
@@ -11,7 +11,7 @@ kubectl create namespace gitea || true
 
 # Restore Persistent Volume from backup for Gitea
 echo "🔐 Restoring Data Volume..."
-./longhorn-automation.sh restore gitea pvc-90375b86-e77a-4bfb-9e91-28cbd4983e18 --wrapper
+./longhorn-automation.sh restore gitea pvc-90375b86-e77a-4bfb-9e91-28cbd4983e18
 echo "✅ Persistent Data Volume Restored!"
 
 # Deploy Gitea

--- a/kubernetes/scripts/helpers/deploy-sealed-secrets.sh
+++ b/kubernetes/scripts/helpers/deploy-sealed-secrets.sh
@@ -20,7 +20,7 @@ echo "🎉 Sealed Secrets deployed!"
 # Wait for the Sealed Secret Key to be created
 echo "⏳ Waiting for sealed secret key to be created..."
 SECRETS_KEY=""
-for i in {1..100}; do
+for i in {1..120}; do
   kubectl get secrets -n kube-system > /dev/null 2>&1  # Force refresh
 
   SECRETS_KEY=$(kubectl get secret -n kube-system | grep sealed-secrets-key | awk '{print $1}' || true)
@@ -30,11 +30,11 @@ for i in {1..100}; do
     break
   fi
 
-  echo "🔄 Still waiting for secret... $((100-i)) seconds left"
+  echo "🔄 Still waiting for secret... $((120-i)) seconds left"
   sleep 1
 done
 
 if [[ -z "$SECRETS_KEY" ]]; then
-  echo "❌ ERROR: Sealed secret key not found after 30 seconds!"
+  echo "❌ ERROR: Sealed secret key not found after 120 seconds!"
   exit 1
 fi

--- a/kubernetes/scripts/main.sh
+++ b/kubernetes/scripts/main.sh
@@ -37,5 +37,8 @@ bash helpers/deploy-trilium.sh
 # Step 8: Deploy Mealie
 bash helpers/deploy-mealie.sh
 
+# Step 9: Deploy Gitea
+bash helpers/deploy-gitea.sh
+
 
 echo "✅ Deployment Completed Successfully!"

--- a/terraform/config/cloud_init.cfg
+++ b/terraform/config/cloud_init.cfg
@@ -58,7 +58,7 @@ runcmd:
 
   # Install K3s Control Plane
   - if [ "${node_type}" = "control-plane" ]; then
-      curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable traefik --tls-san k3s.atlasmalt.com --disable-agent" sh -;
+      curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable traefik --tls-san k3s.atlasmalt.com --node-taint node-role.kubernetes.io/control-plane:NoSchedule --node-label role=control-plane" sh -;
       export K3S_TOKEN=$(sudo cat /var/lib/rancher/k3s/server/node-token);
       echo "$K3S_TOKEN" | tee /home/ubuntu/k3s_token;
       chown ubuntu:ubuntu /home/ubuntu/k3s_token;
@@ -91,5 +91,5 @@ runcmd:
       export K3S_TOKEN=$(ssh -o "StrictHostKeyChecking=no" -i /home/ubuntu/.ssh/id_rsa ubuntu@${control_ip} "cat /home/ubuntu/k3s_token");
       echo "K3S_TOKEN:";
       echo $K3S_TOKEN;
-      curl -sfL https://get.k3s.io | K3S_URL="https://${control_ip}:6443" K3S_TOKEN="$K3S_TOKEN" sh -;
+      curl -sfL https://get.k3s.io | K3S_URL="https://${control_ip}:6443" K3S_TOKEN="$K3S_TOKEN" INSTALL_K3S_EXEC="--node-label longhorn-true --node-label node.longhorn.io/create-default-disk=true" sh -;
     fi


### PR DESCRIPTION
Here’s a concise and informative **PR description** you can use for this set of changes:

---

### 🛠 PR: Fully Automate Gitea Restore Flow with Volume Recovery Support

This PR introduces full support for **restoring Gitea from a Longhorn backup**, including dynamic volume provisioning edge cases where the restored volume name may not match the original.

### ✅ What's Included:

- **🔁 `longhorn-automation.sh` Improvements**
  - Added support for passing an optional `ORIGINAL_VOLUME_ID` to handle dynamically provisioned volumes.
  - Hardened curl usage with `-k` for local HTTPS API calls.
  - Improved logging, error handling, and defaults to make restore behavior predictable.

- **📦 Helm: Gitea Volume Restoration**
  - Introduced new `volumes.yaml` template to declaratively provision Longhorn `Volume`, `PersistentVolume`, and `PersistentVolumeClaim` using Helm.
  - Accepts volume restoration parameters from `values.yaml`, including `fromBackup`, `size`, `storageClassName`, etc.

- **🔒 Secrets + Certs**
  - Gitea is now configured with proper `ROOT_URL`, `DOMAIN`, and `SSH_DOMAIN` using `additionalConfigFromEnvs`.
  - TLS is enabled via Let's Encrypt staging for `git.atlasmalt.com`.

- **🐋 Longhorn Deployment Enhancements**
  - Waits for a `Ready` worker node with the `longhorn-true` label before installation.
  - Automatically applies node annotations and tags expected by Longhorn.
  - Prevents scheduling Longhorn components on the control-plane by honoring taints and node labels.

- **☁️ Terraform / Cloud-Init Changes**
  - Ensures control-plane node is labeled with `role=control-plane` and tainted `NoSchedule`.
  - Worker nodes are labeled for Longhorn and prepared for disk provisioning.

### 🔄 End-to-End Tested:
- Confirmed that `main.sh` script can:
  1. Nuke the cluster,
  2. Re-deploy sealed secrets, Longhorn, and backup configuration,
  3. Restore Gitea from a previous backup,
  4. Serve it at [https://git.atlasmalt.com/](https://git.atlasmalt.com) with full functionality.
